### PR TITLE
fixed link

### DIFF
--- a/README.md
+++ b/README.md
@@ -134,7 +134,7 @@ How do you query a table for the names of its columns? For this we need to use t
 PRAGMA table_info(<table name>)
 ```
 
-This line of code that utilizes <a href="#resources">PRAGMA</a> will return to us (thanks to our handy `#results_as_hash` method) an array of hashes describing the table itself. Each hash will contain information about one column. The array of hashes will look something like this:
+This line of code that utilizes [PRAGMA](https://www.sqlite.org/pragma.html#pragma_table_info) will return to us (thanks to our handy `#results_as_hash` method) an array of hashes describing the table itself. Each hash will contain information about one column. The array of hashes will look something like this:
 
 ```ruby
  [{"cid"=>0,


### PR DESCRIPTION
closes #1 

Hi, thanks for submitting this issue.

We've updated the link to the following URL:
https://www.sqlite.org/pragma.html#pragma_table_info

The changes might take a while to show up on your Canvas instance but the GitHub repo should be updated withing a few minutes.

Thanks again for submitting the issue and helping us improve the curriculum!